### PR TITLE
Initialize Next.js affiliate marketing site

### DIFF
--- a/components/AffiliateButton.tsx
+++ b/components/AffiliateButton.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+interface Props {
+  href: string;
+  children: string;
+}
+
+export default function AffiliateButton({ href, children }: Props) {
+  return (
+    <Link
+      href={href}
+      className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+      target="_blank"
+      rel="nofollow noopener"
+    >
+      {children}
+    </Link>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+export default function Header() {
+  return (
+    <header className="bg-white shadow">
+      <div className="container mx-auto p-4 flex items-center justify-between">
+        <Link href="/">
+          <span className="font-bold text-xl">AI Hustle</span>
+        </Link>
+        <nav className="space-x-4">
+          <Link href="/best-ai-tools-for-freelancers" className="text-blue-600 hover:underline">
+            Best Tools
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,0 +1,24 @@
+import Head from 'next/head';
+import { ReactNode } from 'react';
+import Header from './Header';
+
+interface Props {
+  children: ReactNode;
+  title?: string;
+  description?: string;
+}
+
+export default function Layout({ children, title, description }: Props) {
+  return (
+    <>
+      <Head>
+        <title>{title ? `${title} | AI Hustle` : 'AI Hustle'}</title>
+        {description && <meta name="description" content={description} />}
+      </Head>
+      <div className="min-h-screen flex flex-col">
+        <Header />
+        <main className="flex-1 container mx-auto p-4">{children}</main>
+      </div>
+    </>
+  );
+}

--- a/content/best-ai-tools-for-freelancers.mdx
+++ b/content/best-ai-tools-for-freelancers.mdx
@@ -1,0 +1,12 @@
+---
+title: "Best AI Tools for Freelancers"
+description: "Top AI tools every freelancer should know."
+---
+
+# Best AI Tools for Freelancers
+
+Here are some must-have AI tools to boost your productivity.
+
+1. **Jasper AI** - <AffiliateButton href="https://example.com/jasper">Sign up</AffiliateButton>
+2. **Writesonic** - <AffiliateButton href="https://example.com/writesonic">Sign up</AffiliateButton>
+3. **CopyAI** - <AffiliateButton href="https://example.com/copyai">Sign up</AffiliateButton>

--- a/content/jasper-ai-review.mdx
+++ b/content/jasper-ai-review.mdx
@@ -1,0 +1,20 @@
+---
+title: "Jasper AI Review"
+description: "In-depth review of Jasper AI with pros, cons, and affiliate link."
+---
+
+# Jasper AI Review
+
+Jasper AI is a powerful writing assistant. Here's what we liked and didn't like.
+
+## Pros
+
+- Generates high quality content quickly
+- Easy to use interface
+
+## Cons
+
+- Pricing can be high for beginners
+- Occasional factual errors
+
+<AffiliateButton href="https://example.com/jasper">Try Jasper AI</AffiliateButton>

--- a/content/writesonic-vs-copyai.mdx
+++ b/content/writesonic-vs-copyai.mdx
@@ -1,0 +1,15 @@
+---
+title: "Writesonic vs CopyAI"
+description: "Comparison of Writesonic and CopyAI for marketers."
+---
+
+# Writesonic vs CopyAI
+
+| Feature | Writesonic | CopyAI |
+|---------|-----------|--------|
+| Templates | 80+ | 90+ |
+| Free Plan | Yes | Yes |
+| Price | $$ | $$ |
+
+<AffiliateButton href="https://example.com/writesonic">Try Writesonic</AffiliateButton>
+<AffiliateButton href="https://example.com/copyai">Try CopyAI</AffiliateButton>

--- a/lib/mdx.ts
+++ b/lib/mdx.ts
@@ -1,0 +1,28 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import { serialize } from 'next-mdx-remote/serialize';
+
+const contentDir = path.join(process.cwd(), 'content');
+
+export interface Post {
+  slug: string;
+  frontMatter: Record<string, any>;
+  mdxSource: any;
+}
+
+export async function getPostBySlug(slug: string): Promise<Post | null> {
+  const fullPath = path.join(contentDir, `${slug}.mdx`);
+  if (!fs.existsSync(fullPath)) return null;
+  const file = fs.readFileSync(fullPath, 'utf8');
+  const { content, data } = matter(file);
+  const mdxSource = await serialize(content, { scope: data });
+  return { slug, frontMatter: data, mdxSource };
+}
+
+export function getAllSlugs(): string[] {
+  return fs
+    .readdirSync(contentDir)
+    .filter((f) => f.endsWith('.mdx'))
+    .map((f) => f.replace(/\.mdx$/, ''));
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  pageExtensions: ['ts', 'tsx'],
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "ai-hustle-stack",
+  "version": "1.0.0",
+  "description": "Affiliate marketing site",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo \"No tests specified\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "next": "15.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "next-mdx-remote": "4.3.0",
+    "gray-matter": "4.0.3"
+  },
+  "devDependencies": {
+    "typescript": "5.2.2",
+    "@types/react": "18.0.28",
+    "@types/node": "20.4.2",
+    "autoprefixer": "10.4.12",
+    "postcss": "8.4.18",
+    "tailwindcss": "3.3.2"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,13 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  // @ts-ignore
+  const { title, description } = pageProps?.frontMatter || {};
+  const Layout = require('../components/Layout').default;
+  return (
+    <Layout title={title} description={description}>
+      <Component {...pageProps} />
+    </Layout>
+  );
+}

--- a/pages/best-ai-tools-for-freelancers.tsx
+++ b/pages/best-ai-tools-for-freelancers.tsx
@@ -1,0 +1,15 @@
+import { GetStaticProps } from 'next';
+import { MDXRemote } from 'next-mdx-remote';
+import { getPostBySlug } from '../lib/mdx';
+import AffiliateButton from '../components/AffiliateButton';
+
+const components = { AffiliateButton };
+
+export const getStaticProps: GetStaticProps = async () => {
+  const post = await getPostBySlug('best-ai-tools-for-freelancers');
+  return { props: { ...post } };
+};
+
+export default function BestToolsPage({ mdxSource }: any) {
+  return <MDXRemote {...mdxSource} components={components} />;
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+import { getAllSlugs } from '../lib/mdx';
+
+export async function getStaticProps() {
+  const slugs = getAllSlugs().filter((s) => s !== 'best-ai-tools-for-freelancers');
+  return { props: { slugs } };
+}
+
+export default function Home({ slugs }: { slugs: string[] }) {
+  return (
+    <div>
+      <h1 className="text-3xl font-bold mb-4">AI Tool Reviews</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {slugs.map((slug) => (
+          <Link key={slug} href={`/tools/${slug}`} className="p-4 bg-white rounded shadow">
+            {slug.replace(/-/g, ' ')}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/pages/tools/[slug].tsx
+++ b/pages/tools/[slug].tsx
@@ -1,0 +1,22 @@
+import { GetStaticPaths, GetStaticProps } from 'next';
+import { MDXRemote } from 'next-mdx-remote';
+import { getAllSlugs, getPostBySlug } from '../../lib/mdx';
+import AffiliateButton from '../../components/AffiliateButton';
+
+const components = { AffiliateButton };
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const slugs = getAllSlugs().filter((s) => !s.startsWith('best-ai-tools'));
+  const paths = slugs.map((slug) => ({ params: { slug } }));
+  return { paths, fallback: false };
+};
+
+export const getStaticProps: GetStaticProps = async ({ params }) => {
+  const slug = params?.slug as string;
+  const post = await getPostBySlug(slug);
+  return { props: { ...post } };
+};
+
+export default function ToolPage({ mdxSource, frontMatter }: any) {
+  return <MDXRemote {...mdxSource} components={components} />;
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-50 text-gray-900 antialiased;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+    './content/**/*.mdx'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js 15 site with TypeScript and TailwindCSS
- add Layout, Header, and AffiliateButton components
- render MDX-based content with dynamic routes
- add sample content and SEO metadata

## Testing
- `npm install` *(fails: 403 Forbidden – registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6860b86922b48332acff55b750995b3c