### PR TITLE
Add blog post on AI tools for social media managers

### DIFF
--- a/content/best-ai-tools-for-social-media-managers.mdx
+++ b/content/best-ai-tools-for-social-media-managers.mdx
@@ -1,0 +1,30 @@
+---
+title: "Best AI Tools for Social Media Managers"
+description: "Top AI solutions to streamline social media management tasks."
+slug: "best-ai-tools-for-social-media-managers"
+keywords:
+  - ai tools
+  - social media management
+  - automation
+affiliateLinks:
+  - name: "Hootsuite AI"
+    url: "https://example.com/hootsuite"
+  - name: "Buffer AI"
+    url: "https://example.com/buffer"
+  - name: "LatelyAI"
+    url: "https://example.com/lately"
+---
+
+# Best AI Tools for Social Media Managers
+
+Managing multiple platforms every day is tough. The best AI tools for social media managers help automate scheduling, analytics, and content creation, freeing up time for strategy.
+
+| Tool | Price | Pros | Cons | CTA |
+|------|-------|------|------|-----|
+| **Hootsuite AI** | From $99/mo | All-in-one dashboard, smart scheduling | Steep learning curve | <AffiliateButton href="https://example.com/hootsuite">Try Hootsuite AI</AffiliateButton> |
+| **Buffer AI** | Free plan, then $6/mo | Simple interface, AI-powered suggestions | Limited advanced analytics | <AffiliateButton href="https://example.com/buffer">Get Buffer AI</AffiliateButton> |
+| **LatelyAI** | Custom pricing | Generates posts from long-form content | No built-in scheduling | <AffiliateButton href="https://example.com/lately">Explore LatelyAI</AffiliateButton> |
+
+## Which should you pick?
+
+If you need a robust platform with serious scheduling power, **Hootsuite AI** is the best pick. For a budget-friendly option with AI writing tips, **Buffer AI** works great. Meanwhile, **LatelyAI** excels at transforming existing content into fresh social posts. Choose the tool that matches your workflow and budget, then start automating your social media hustle today.

--- a/pages/best-ai-tools-for-social-media-managers.tsx
+++ b/pages/best-ai-tools-for-social-media-managers.tsx
@@ -1,0 +1,15 @@
+import { GetStaticProps } from 'next';
+import { MDXRemote } from 'next-mdx-remote';
+import { getPostBySlug } from '../lib/mdx';
+import AffiliateButton from '../components/AffiliateButton';
+
+const components = { AffiliateButton };
+
+export const getStaticProps: GetStaticProps = async () => {
+  const post = await getPostBySlug('best-ai-tools-for-social-media-managers');
+  return { props: { ...post } };
+};
+
+export default function BestSocialMediaToolsPage({ mdxSource }: any) {
+  return <MDXRemote {...mdxSource} components={components} />;
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,11 @@ import Link from 'next/link';
 import { getAllSlugs } from '../lib/mdx';
 
 export async function getStaticProps() {
-  const slugs = getAllSlugs().filter((s) => s !== 'best-ai-tools-for-freelancers');
+  const slugs = getAllSlugs().filter(
+    (s) =>
+      s !== 'best-ai-tools-for-freelancers' &&
+      s !== 'best-ai-tools-for-social-media-managers'
+  );
   return { props: { slugs } };
 }
 


### PR DESCRIPTION
## Summary
- add new affiliate post for social media managers
- add page for the new post
- filter new slug from home page list

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860ba8086ac8332a3ae5c7cf5be4d92