### PR TITLE
Add OpenAI SDK config

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your-key-here

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "next-mdx-remote": "4.3.0",
-    "gray-matter": "4.0.3"
+    "gray-matter": "4.0.3",
+    "openai": "^4.25.0"
   },
   "devDependencies": {
     "typescript": "5.2.2",


### PR DESCRIPTION
## Summary
- install OpenAI SDK dependency
- configure `.env.local` placeholder
- confirm TypeScript `esModuleInterop`

## Testing
- `npm test`
- `npm install openai` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2Fnode)*

------
https://chatgpt.com/codex/tasks/task_e_6860befb09088332aed1ff57e001d649