### PR TITLE
Fix import path for AffiliateButton

### DIFF
--- a/pages/tools/[slug].tsx
+++ b/pages/tools/[slug].tsx
@@ -6,7 +6,7 @@ import matter from "gray-matter";
 import { GetStaticPaths, GetStaticProps } from "next";
 import { serialize } from "next-mdx-remote/serialize";
 import { MDXRemote } from "next-mdx-remote";
-import AffiliateButton from "@/components/AffiliateButton";
+import AffiliateButton from "../../components/AffiliateButton";
 import Head from "next/head";
 
 const components = {


### PR DESCRIPTION
## Summary
- fix missing path alias for AffiliateButton component

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c3dfb0a883328fbee12831325aa3