### PR TITLE
Add MDX plugin configuration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,7 @@
-import { withMDX } from '@next/mdx'
-
-const nextConfig = withMDX({
-  extension: /\.mdx?$/,
-  options: {},
-})({
-  pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'mdx'],
+const withMDX = require('@next/mdx')({
+  extension: /\.mdx?$/
 })
 
-export default nextConfig
+module.exports = withMDX({
+  pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'mdx']
+})


### PR DESCRIPTION
## Summary
- set up MDX plugin in `next.config.js`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860cda6a3f0833293ce3d7f51c4d868